### PR TITLE
Introduce scss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sass-cache

--- a/public/css/README.md
+++ b/public/css/README.md
@@ -1,0 +1,20 @@
+For those CSS files that have a SCSS file, the CSS file should never be edited
+directly. These are generated from the SCSS file.
+
+```
+sass solidare-it.scss:solidare-it.css
+```
+
+To install the tool that does this transformation : [SASS](http://sass-lang.com/docs.html)
+you can do
+
+```
+gem install sass
+```
+
+When working on the CSS it can be the easiest to have the CSS update itself
+automatically based on the SCSS. In this case use
+
+```
+sass --watch solidare-it.scss:solidare-it.css
+```

--- a/public/css/solidare-it.css
+++ b/public/css/solidare-it.css
@@ -1,174 +1,131 @@
-.logo{
-	height:100px;
-	padding:10px;	
-}
+.logo {
+  height: 100px;
+  padding: 10px; }
 
-.navbar-inner{
-	background-color:#ee0092;
-	background-image:none;
-}
+.navbar-inner {
+  background-color: #ee0092;
+  background-image: none; }
 
-.navbar .nav > .active > a, .navbar .nav > .active > a:hover, .navbar .nav > .active > a:focus{
-	background-color:#747476;
-	color:#fff;
-}
-
-.navbar .nav > li > a, .navbar .nav > li > a:hover, .navbar .nav > li > a:focus{
-	color:#343436;
-	text-shadow:none;	
-}
-
-.navbar .nav > li > a{
-	color: #fff;
-}
-
-.navbar{
-	margin-bottom: 0px;
-}
-
-.navigation{
-	margin-bottom: 20px;
-}
-
-.header{
-	background-color: #E0E0E0;
-}
-
-.headerInfo{
-	height: 120px;
-	background-color: rgba(255,255,255,0.5);
-}
-
-.searchArea{
-	background-color: rgba(255,255,255,0.5);
-	height:40px;
-}
-
-.navigation{
-	background-color: #EE0092;
-	border-bottom: 4px solid #747476;
-}
-
-.navbar-inner{
-	border:none;
-	font-weight:bold;
-}
-
-.navbar-search{
-	margin-left:10px;
-}
-
-.search-query{
-	border: 1px solid #747476;
-}
-
-.btn-primary{
-	border-radius: 15px;
-}
-
-.pageBlock{
-	border-top:9px solid #E0E0E0; 
-	padding: 5px;
-}
-
-.pageBlock.primary{
-	border-top-color: #ee0092;
-}
-
-.pageBlock.bold{
-	border-top-color: #747476;
-	background-color: #E0E0E0;
-}
-
-.pageBlock.dark{
-	border-top-color: #747476;
-	background-color: #747476;
-	color: #fff;
-}
-
-.homeHeader{
-	margin-bottom:10px;
-}
-
-.progress {
+.navbar {
+  margin-bottom: 0px; }
+  .navbar .nav > .active > a, .navbar .nav > .active > a:hover, .navbar .nav > .active > a:focus {
     background-color: #747476;
-    background-image: linear-gradient(to bottom, #787880, #707072);
-}
+    color: white; }
+  .navbar .nav > li > a, .navbar .nav > li > a:hover, .navbar .nav > li > a:focus {
+    color: #343436;
+    text-shadow: none; }
+  .navbar .nav > li > a {
+    color: white; }
 
-.progress .bar {
-    background-color: #ee0092;
-    background-image: linear-gradient(to bottom, #ee0092, #ee0092);
-}
+.header {
+  background-color: #e0e0e0; }
 
-.progress.challenge{
-	height:30px;
-}
+.headerInfo {
+  height: 120px;
+  background-color: rgba(255, 255, 255, 0.5); }
 
-.progress.challenge .bar
-{
-	padding-top:6px;
-	vertical-align:middle;
-	font-size:14px;
-	font-weight:bold;
-}
+.searchArea {
+  background-color: rgba(255, 255, 255, 0.5);
+  height: 40px; }
 
-a.btn, a.btn-primary{
-	text-align: center;
-	vertical-align: middle;
-	padding-top:6px;
-}
+.navigation {
+  margin-bottom: 20px;
+  background-color: #ee0092;
+  border-bottom: 4px solid #747476; }
 
-.exclamation{
-	text-align:center;
-	font-weight:bold;
-	margin-bottom:20px;
-	font-size:18px;
-}
+.navbar-inner {
+  border: none;
+  font-weight: bold; }
 
-.inscriptionChoice{
-	border: 2px solid #747476;
-	padding: 10px;
-	border-radius: 10px;
-	height:100px;
-	margin-bottom: 5px;
-	text-align:center;
-}
+.navbar-search {
+  margin-left: 10px; }
 
-.social-icon.small{
-	width:20px;
-}
+.search-query {
+  border: 1px solid #747476; }
 
 .btn-primary {
-    background-color: #EE0072;
-    background-image: linear-gradient(to bottom, #EE0072, #EE0072);
-	font-weight:bold;
-}
+  border-radius: 15px; }
 
-.counter{
-	border:1px solid #B5B5B5;
-	padding:0px 3px 0px 3px;
-	color:#ee0092;
-	font-weight:bold;
-	background-color:#fff;
-}
+.pageBlock {
+  border-top: 9px solid #e0e0e0;
+  padding: 5px; }
 
-.counterHeader{
-	font-weight:bold;
-	height:20px;
-}
+.pageBlock.primary {
+  border-top-color: #ee0092; }
 
-.dareIt{
-	padding-top:2px;
-	font-weight:bold;
-}
+.pageBlock.bold {
+  border-top-color: #747476;
+  background-color: #e0e0e0; }
 
-.dareIt span.light{
-	color:#fff;	
-	font-size:18px;
-	
-}
+.pageBlock.dark {
+  border-top-color: #747476;
+  background-color: #747476;
+  color: white; }
 
-.dareIt span.dark{
-	color:#000;
-	font-weight:bolder;
-}
+.homeHeader {
+  margin-bottom: 10px; }
+
+.progress {
+  background-color: #747476;
+  background-image: linear-gradient(to bottom, #787880, #707072); }
+
+.progress .bar {
+  background-color: #ee0092; }
+
+.progress.challenge {
+  height: 30px; }
+
+.progress.challenge .bar {
+  padding-top: 6px;
+  vertical-align: middle;
+  font-size: 14px;
+  font-weight: bold; }
+
+a.btn, a.btn-primary {
+  text-align: center;
+  vertical-align: middle;
+  padding-top: 6px; }
+
+.exclamation {
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 20px;
+  font-size: 18px; }
+
+.inscriptionChoice {
+  border: 2px solid #747476;
+  padding: 10px;
+  border-radius: 10px;
+  height: 100px;
+  margin-bottom: 5px;
+  text-align: center; }
+
+.social-icon.small {
+  width: 20px; }
+
+.btn-primary {
+  background-color: #ee0072;
+  font-weight: bold; }
+
+.counter {
+  border: 1px solid #b5b5b5;
+  padding: 0px 3px 0px 3px;
+  color: #ee0092;
+  font-weight: bold;
+  background-color: white; }
+
+.counterHeader {
+  font-weight: bold;
+  height: 20px; }
+
+.dareIt {
+  padding-top: 2px;
+  font-weight: bold; }
+
+.dareIt span.light {
+  color: white;
+  font-size: 18px; }
+
+.dareIt span.dark {
+  color: black;
+  font-weight: bolder; }

--- a/public/css/solidare-it.scss
+++ b/public/css/solidare-it.scss
@@ -45,32 +45,32 @@ $dare_it_light_fg:                    $palette_G1;
 $dare_it_dark_fg:                     $palette_G8;
 
 .logo{
-	height: 100px;
-	padding: 10px;
+  height: 100px;
+  padding: 10px;
 }
 
 .navbar-inner{
-	background-color: $navbar_bg;
-	background-image: none;
+  background-color: $navbar_bg;
+  background-image: none;
 }
 
 .navbar {
-	margin-bottom: 0px;
+  margin-bottom: 0px;
 
   .nav {
     & > .active {
       & > a, & > a:hover, & > a:focus {
-  	    background-color: $navbar_active_bg;
-  	    color:            $navbar_active_fg;
+        background-color: $navbar_active_bg;
+        color:            $navbar_active_fg;
       }
     }
     & > li {
       & > a, & > a:hover, & > a:focus{
-  	    color:            $navbar_li_hover_fg;
-  	    text-shadow:none;
+        color:            $navbar_li_hover_fg;
+        text-shadow:none;
       }
       & > a {
-  	    color:            $navbar_li_fg;
+        color:            $navbar_li_fg;
       }
     }
   }
@@ -80,64 +80,64 @@ $dare_it_dark_fg:                     $palette_G8;
 }
 
 .header {
-	background-color: $header_bg;
+  background-color: $header_bg;
 }
 
 .headerInfo {
-	height: 120px;
-	background-color: rgba(255,255,255,0.5);
+  height: 120px;
+  background-color: rgba(255,255,255,0.5);
 }
 
 .searchArea {
-	background-color: rgba(255,255,255,0.5);
-	height:40px;
+  background-color: rgba(255,255,255,0.5);
+  height:40px;
 }
 
 .navigation {
-	margin-bottom: 20px;
-	background-color: $navigation_bg;
-	border-bottom: 4px solid $navigation_border_color;
+  margin-bottom: 20px;
+  background-color: $navigation_bg;
+  border-bottom: 4px solid $navigation_border_color;
 }
 
 .navbar-inner {
-	border:none;
-	font-weight:bold;
+  border:none;
+  font-weight:bold;
 }
 
 .navbar-search {
-	margin-left:10px;
+  margin-left:10px;
 }
 
 .search-query {
-	border: 1px solid $search_query_border_color;
+  border: 1px solid $search_query_border_color;
 }
 
 .btn-primary {
-	border-radius: 15px;
+  border-radius: 15px;
 }
 
 .pageBlock {
-	border-top:9px solid $page_block_top_border_color;
-	padding: 5px;
+  border-top:9px solid $page_block_top_border_color;
+  padding: 5px;
 }
 
 .pageBlock.primary {
-	border-top-color: $page_block_primary_top_border_color;
+  border-top-color: $page_block_primary_top_border_color;
 }
 
 .pageBlock.bold {
-	border-top-color: $page_block_bold_top_border_color;
-	background-color: $page_block_bold_bg;
+  border-top-color: $page_block_bold_top_border_color;
+  background-color: $page_block_bold_bg;
 }
 
 .pageBlock.dark {
-	border-top-color: $page_block_dark_top_border_color;
-	background-color: $page_block_dark_bg;
-	color:            $page_block_dark_fg;
+  border-top-color: $page_block_dark_top_border_color;
+  background-color: $page_block_dark_bg;
+  color:            $page_block_dark_fg;
 }
 
 .homeHeader {
-	margin-bottom:10px;
+  margin-bottom:10px;
 }
 
 .progress {
@@ -150,40 +150,40 @@ $dare_it_dark_fg:                     $palette_G8;
 }
 
 .progress.challenge {
-	height:30px;
+  height:30px;
 }
 
 .progress.challenge .bar {
-	padding-top:6px;
-	vertical-align:middle;
-	font-size:14px;
-	font-weight:bold;
+  padding-top:6px;
+  vertical-align:middle;
+  font-size:14px;
+  font-weight:bold;
 }
 
 a.btn, a.btn-primary {
-	text-align: center;
-	vertical-align: middle;
-	padding-top:6px;
+  text-align: center;
+  vertical-align: middle;
+  padding-top:6px;
 }
 
 .exclamation {
-	text-align:center;
-	font-weight:bold;
-	margin-bottom:20px;
-	font-size:18px;
+  text-align:center;
+  font-weight:bold;
+  margin-bottom:20px;
+  font-size:18px;
 }
 
 .inscriptionChoice {
-	border: 2px solid $inscription_choice_border_color;
-	padding: 10px;
-	border-radius: 10px;
-	height:100px;
-	margin-bottom: 5px;
-	text-align:center;
+  border: 2px solid $inscription_choice_border_color;
+  padding: 10px;
+  border-radius: 10px;
+  height:100px;
+  margin-bottom: 5px;
+  text-align:center;
 }
 
 .social-icon.small {
-	width:20px;
+  width:20px;
 }
 
 .btn-primary {
@@ -192,29 +192,29 @@ a.btn, a.btn-primary {
 }
 
 .counter {
-	border:1px solid $counter_border_color;
-	padding:0px 3px 0px 3px;
-	color: $counter_fg;
-	font-weight:bold;
-	background-color: $counter_bg;
+  border:1px solid $counter_border_color;
+  padding:0px 3px 0px 3px;
+  color: $counter_fg;
+  font-weight:bold;
+  background-color: $counter_bg;
 }
 
 .counterHeader {
-	font-weight:bold;
-	height:20px;
+  font-weight:bold;
+  height:20px;
 }
 
 .dareIt {
-	padding-top:2px;
-	font-weight:bold;
+  padding-top:2px;
+  font-weight:bold;
 }
 
 .dareIt span.light {
-	color: $dare_it_light_fg;
-	font-size:18px;
+  color: $dare_it_light_fg;
+  font-size:18px;
 }
 
 .dareIt span.dark {
-	color: $dare_it_dark_fg;
-	font-weight:bolder;
+  color: $dare_it_dark_fg;
+  font-weight:bolder;
 }

--- a/public/css/solidare-it.scss
+++ b/public/css/solidare-it.scss
@@ -1,0 +1,220 @@
+$palette_A1: #EE0092;
+$palette_A2: #EE0072;
+
+$palette_G1: #FFFFFF;
+$palette_G2: #E0E0E0;
+$palette_G3: #B5B5B5;
+$palette_G4: #787880;
+$palette_G5: #747476;
+$palette_G6: #707072;
+$palette_G7: #343436;
+$palette_G8: #000000;
+
+$navbar_bg:                           $palette_A1;
+$navbar_active_bg:                    $palette_G5;
+$navbar_active_fg:                    $palette_G1;
+$navbar_li_fg:                        $palette_G1;
+$navbar_li_hover_fg:                  $palette_G7;
+
+$header_bg:                           $palette_G2;
+$navigation_bg:                       $palette_A1;
+$navigation_border_color:             $palette_G5;
+$search_query_border_color:           $palette_G5;
+
+$page_block_top_border_color:         $palette_G2;
+$page_block_primary_top_border_color: $palette_A1;
+$page_block_bold_top_border_color:    $palette_G5;
+$page_block_bold_bg:                  $palette_G2;
+$page_block_dark_top_border_color:    $palette_G5;
+$page_block_dark_bg:                  $palette_G5;
+$page_block_dark_fg:                  $palette_G1;
+
+$progress_bg:                         $palette_G5;
+$progress_bg_start:                   $palette_G4;
+$progress_bg_end:                     $palette_G6;
+$progress_bar_bg:                     $palette_A1;
+
+$inscription_choice_border_color:     $palette_G5;
+$button_primary_bg:                   $palette_A2;
+
+$counter_fg:                          $palette_A1;
+$counter_bg:                          $palette_G1;
+$counter_border_color:                $palette_G3;
+
+$dare_it_light_fg:                    $palette_G1;
+$dare_it_dark_fg:                     $palette_G8;
+
+.logo{
+	height: 100px;
+	padding: 10px;
+}
+
+.navbar-inner{
+	background-color: $navbar_bg;
+	background-image: none;
+}
+
+.navbar {
+	margin-bottom: 0px;
+
+  .nav {
+    & > .active {
+      & > a, & > a:hover, & > a:focus {
+  	    background-color: $navbar_active_bg;
+  	    color:            $navbar_active_fg;
+      }
+    }
+    & > li {
+      & > a, & > a:hover, & > a:focus{
+  	    color:            $navbar_li_hover_fg;
+  	    text-shadow:none;
+      }
+      & > a {
+  	    color:            $navbar_li_fg;
+      }
+    }
+  }
+}
+
+.navigation {
+}
+
+.header {
+	background-color: $header_bg;
+}
+
+.headerInfo {
+	height: 120px;
+	background-color: rgba(255,255,255,0.5);
+}
+
+.searchArea {
+	background-color: rgba(255,255,255,0.5);
+	height:40px;
+}
+
+.navigation {
+	margin-bottom: 20px;
+	background-color: $navigation_bg;
+	border-bottom: 4px solid $navigation_border_color;
+}
+
+.navbar-inner {
+	border:none;
+	font-weight:bold;
+}
+
+.navbar-search {
+	margin-left:10px;
+}
+
+.search-query {
+	border: 1px solid $search_query_border_color;
+}
+
+.btn-primary {
+	border-radius: 15px;
+}
+
+.pageBlock {
+	border-top:9px solid $page_block_top_border_color;
+	padding: 5px;
+}
+
+.pageBlock.primary {
+	border-top-color: $page_block_primary_top_border_color;
+}
+
+.pageBlock.bold {
+	border-top-color: $page_block_bold_top_border_color;
+	background-color: $page_block_bold_bg;
+}
+
+.pageBlock.dark {
+	border-top-color: $page_block_dark_top_border_color;
+	background-color: $page_block_dark_bg;
+	color:            $page_block_dark_fg;
+}
+
+.homeHeader {
+	margin-bottom:10px;
+}
+
+.progress {
+    background-color: $progress_bg;
+    background-image: linear-gradient(to bottom, $progress_bg_start, $progress_bg_end);
+}
+
+.progress .bar {
+    background-color: $progress_bar_bg;
+}
+
+.progress.challenge {
+	height:30px;
+}
+
+.progress.challenge .bar {
+	padding-top:6px;
+	vertical-align:middle;
+	font-size:14px;
+	font-weight:bold;
+}
+
+a.btn, a.btn-primary {
+	text-align: center;
+	vertical-align: middle;
+	padding-top:6px;
+}
+
+.exclamation {
+	text-align:center;
+	font-weight:bold;
+	margin-bottom:20px;
+	font-size:18px;
+}
+
+.inscriptionChoice {
+	border: 2px solid $inscription_choice_border_color;
+	padding: 10px;
+	border-radius: 10px;
+	height:100px;
+	margin-bottom: 5px;
+	text-align:center;
+}
+
+.social-icon.small {
+	width:20px;
+}
+
+.btn-primary {
+    background-color: $button_primary_bg;
+    font-weight:bold;
+}
+
+.counter {
+	border:1px solid $counter_border_color;
+	padding:0px 3px 0px 3px;
+	color: $counter_fg;
+	font-weight:bold;
+	background-color: $counter_bg;
+}
+
+.counterHeader {
+	font-weight:bold;
+	height:20px;
+}
+
+.dareIt {
+	padding-top:2px;
+	font-weight:bold;
+}
+
+.dareIt span.light {
+	color: $dare_it_light_fg;
+	font-size:18px;
+}
+
+.dareIt span.dark {
+	color: $dare_it_dark_fg;
+	font-weight:bolder;
+}


### PR DESCRIPTION
```
Refactor the CSS to use SASS/SCSS

I have moved the original CSS file to solidare-it.scss, then did some
refactorings to leverage some of the benefits of SCSS. In particular
I seperated the color palette definition from its use.

Note that even though I have included the CSS file that is now generated by
SASS, it should never be directly edited!

To install SASS, given you have Rubygems available is simply

  gem install sass

To then generate the CSS from the source file, use

  sass solidare-it.scss:solidare-it.css
```
