### PR TITLE
Add Travis Continuous Integration configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+
+script: bin/ci_tests
+
+notifications:
+  email:
+    - arne.brasseur@gmail.com
+    - gert.gielen1@gmail.com

--- a/bin/ci_tests
+++ b/bin/ci_tests
@@ -1,0 +1,2 @@
+#!/bin/sh
+phpunit --configuration module/Pages/tests/phpunit.xml


### PR DESCRIPTION
Travis is a free Continuous Integration service. It's a great way to make sure all unit tests are green before merging things in.

This sets up a small config file so Travis knows how to find the tests.
